### PR TITLE
Let enter key accept phonetic input

### DIFF
--- a/jQuery.chineseIME.js
+++ b/jQuery.chineseIME.js
@@ -295,6 +295,13 @@ var _callbacks_ = {
                         self.previousPage();
                     } else if (key == '.') { // go to next page
                         self.nextPage();
+                    } else if (event.which == 13) {
+                        // enter key pressed -- accept phonetic input
+                        self.addText(self.currentText);
+                        self.currentText = '';
+                        self.currentPage = 0;
+                        self.currentSelection = 1;
+                        self.lastPage = false;
                     }
                 } else {
                     if (key == '.') { // pressed period


### PR DESCRIPTION
Currently, the user has to check and uncheck the "phonetic typing" checkbox in order to type latin characters. This commit allows the user to press the "enter" key in order to accept the recognized input as phonetic. This is similar to the way that Chinese typing works on OS X.
