### PR TITLE
Allow plugin on HTTPS server

### DIFF
--- a/jQuery.chineseIME.js
+++ b/jQuery.chineseIME.js
@@ -183,7 +183,7 @@ var _callbacks_ = {
         self.lastPage = false; // are we at the last page of options?
         //self.options = [];
         self.html = '<span class="typing"></span><ul class="options"></ul>';
-        self.url = 'http://www.google.com/inputtools/request?ime=pinyin&ie=utf-8&oe=utf-8&app=translate&uv'
+        self.url = '//www.google.com/inputtools/request?ime=pinyin&ie=utf-8&oe=utf-8&app=translate&uv'
         self.paramNames = {'text': 'text',
                            'num': 'num',
                            'callback': 'cb'}


### PR DESCRIPTION
I had to remove the protocol from the Google url in order to use this plugin on our https website.
